### PR TITLE
Match pxls.world canvases for pxls embeds

### DIFF
--- a/extensions/pxls_embed.py
+++ b/extensions/pxls_embed.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 if TYPE_CHECKING:
     from main import Isabel
 
-PXLS_REGEX = re.compile(r"(?:https?://)?(?:www\.)?pxls\.space/#\S+")
+PXLS_REGEX = re.compile(r"(?:https?://)?(?:[a-z0-9\-]+\.)?pxls\.(space|world)/#\S+")
 
 
 class PxlsEmbedCog(commands.Cog):

--- a/extensions/pxls_embed.py
+++ b/extensions/pxls_embed.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 if TYPE_CHECKING:
     from main import Isabel
 
-PXLS_REGEX = re.compile(r"(?:https?://)?(?:[a-z0-9\-]+\.)?pxls\.(space|world)/#\S+")
+PXLS_REGEX = re.compile(r"(?:https?://)?((?:www\.)?pxls\.space|(?:[a-z0-9\-]+\.)?pxls\.world)/#\S+")
 
 
 class PxlsEmbedCog(commands.Cog):


### PR DESCRIPTION
This changes the regex for pxls embeds to match `pxls.world` and its subdomains, including the Sinder canvas and any future canvases hosted under `pxls.world` (which it seems like is the purpose of `pxls.world` - to host canvases for people)